### PR TITLE
Include port in request url if project is running locally

### DIFF
--- a/mapApp/static/mapApp/js/index.js
+++ b/mapApp/static/mapApp/js/index.js
@@ -2,8 +2,10 @@
 var collisions, nearmisses, hazards, thefts, newInfrastructures;
 
 //'159.203.2.12' for dev
+var localHostnames = ['127.0.0.1', 'localhost'];
 var srv = window.location.hostname;
-
+if (localHostnames.includes(srv))
+  srv = srv + ':' + window.location.port;
 loadIncidenLayerXHR("/nearmisses_tiny?format=json", "nearmiss", nearmisses);
 loadIncidenLayerXHR("/hazards_tiny?format=json", "hazard", hazards);
 loadIncidenLayerXHR("/thefts_tiny?format=json", "theft", thefts);

--- a/mapApp/static/mapApp/js/index.js
+++ b/mapApp/static/mapApp/js/index.js
@@ -2,10 +2,13 @@
 var collisions, nearmisses, hazards, thefts, newInfrastructures;
 
 //'159.203.2.12' for dev
-var localHostnames = ['127.0.0.1', 'localhost'];
 var srv = window.location.hostname;
-if (localHostnames.includes(srv))
+
+// If running locally, include port in API requests
+if (window.location.port) {
   srv = srv + ':' + window.location.port;
+}
+
 loadIncidenLayerXHR("/nearmisses_tiny?format=json", "nearmiss", nearmisses);
 loadIncidenLayerXHR("/hazards_tiny?format=json", "hazard", hazards);
 loadIncidenLayerXHR("/thefts_tiny?format=json", "theft", thefts);


### PR DESCRIPTION
Fixes bug where local API requests would be made to 'localhost' instead of 'localhost:8000' (or whatever port project is running on)

![image](https://user-images.githubusercontent.com/3713996/142071885-1c4c8ae1-8dc9-4b3f-99be-0b5dbafa821c.png)
