### PR TITLE
Bugfix/admin page

### DIFF
--- a/blogApp/models/post.py
+++ b/blogApp/models/post.py
@@ -49,5 +49,8 @@ class Post(models.Model):
     def __unicode__(self):
         return str(self.title)
 
+    def __str__(self):
+        return str(self.title)
+
     class Meta:
         app_label = 'blogApp'

--- a/blogApp/models/post.py
+++ b/blogApp/models/post.py
@@ -17,14 +17,14 @@ class Post(models.Model):
         ('en', _('English')),
         ('fr', _('French'))
     )
-    
+
     date = models.DateTimeField(_('Date created'), auto_now_add=True)
 
     title = models.CharField(_('Title'), max_length=100)
     description = models.CharField(_('Description'), max_length=300)
     post_date = models.DateTimeField(_('Date posted'), default=datetime.now)
     slug = models.SlugField(
-        _('Slug'), unique=True, blank=True, max_length=100, unique_for_date='created')
+        _('Slug'), unique=True, blank=True, max_length=100, unique_for_date='date')
     published = models.BooleanField(_('Published'), default=False)
     content = models.TextField(_('Content'), blank=True)
     language = models.CharField(
@@ -33,7 +33,7 @@ class Post(models.Model):
         choices=LANGUAGE_CHOICES,
         default='en'
     )
-    
+
 
     def get_absolute_url(self):
         return reverse('blogApp:view_post', kwargs={'slug': self.slug})

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}" />{% endblock %}
 


### PR DESCRIPTION
- fixes bug where admin page would crash with django 3
- fixes bug where creating posts would crash because 'slugfield' initializing with nonexistent 'created' field
- gives posts titles in admin page instead of 'post object' numbers 

![image](https://user-images.githubusercontent.com/3713996/142072526-a665949c-d49e-43b5-9592-399c894e31d9.png)

![image](https://user-images.githubusercontent.com/3713996/142072492-bc74a3e0-c994-490d-951b-abd9909a37fc.png)
