### PR TITLE
add report_date to incident weather serializer

### DIFF
--- a/mapApp/serializers.py
+++ b/mapApp/serializers.py
@@ -53,7 +53,7 @@ class IncidentWeatherSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Incident
         geo_field = 'geom'
-        fields = ('i_type', 'incident_with', 'date', 'p_type','personal_involvement',
+        fields = ('i_type', 'incident_with', 'date', 'report_date', 'p_type','personal_involvement',
                   'details', 'injury', 'trip_purpose',
                   'regular_cyclist', 'helmet', 'road_conditions',
                   'sightlines', 'cars_on_roadside', 'bike_lights', 'terrain', 'aggressive', 'intersection',

--- a/mapApp/serializers.py
+++ b/mapApp/serializers.py
@@ -4,7 +4,7 @@ from django.forms import widgets
 from push_notifications.models import GCMDevice, APNSDevice
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
-from mapApp.models import Point, Incident, Hazard, Theft, Official, AlertArea,NewInfrastructure
+from mapApp.models import Point, Incident, Hazard, Theft, Official, AlertArea,NewInfrastructure, Weather
 
 from django.contrib.auth import get_user_model
 User = get_user_model()
@@ -23,11 +23,12 @@ class IncidentSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Incident
         geo_field = 'geom'
-        fields = ('i_type', 'incident_with', 'date', 'p_type', 'personal_involvement',
+        fields = ('i_type', 'incident_with', 'date', 'report_date',
+        'p_type', 'personal_involvement',
                   'details', 'injury', 'trip_purpose',
                   'regular_cyclist', 'helmet', 'road_conditions',
                   'sightlines', 'cars_on_roadside', 'bike_lights', 'terrain', 'aggressive', 'intersection',
-                  'witness_vehicle','bicycle_type',
+                  'witness_vehicle','bicycle_type',  'ebike',
                   'direction', 'turning', 'age', 'birthmonth', 'sex', 'pk', 'impact','infrastructure_changed',
                   'infrastructure_changed_date')
 

--- a/mapApp/serializers.py
+++ b/mapApp/serializers.py
@@ -57,7 +57,7 @@ class IncidentWeatherSerializer(GeoFeatureModelSerializer):
                   'details', 'injury', 'trip_purpose',
                   'regular_cyclist', 'helmet', 'road_conditions',
                   'sightlines', 'cars_on_roadside', 'bike_lights', 'terrain', 'aggressive', 'intersection',
-                  'witness_vehicle','bicycle_type',
+                  'witness_vehicle','bicycle_type', 'ebike',
                   'direction', 'turning', 'age', 'birthmonth', 'sex', 'pk', 'impact', 'weather_summary',
                   'weather_sunrise_time', 'weather_sunset_time', 'weather_dawn', 'weather_dusk',
                   'weather_precip_intensity', 'weather_precip_probability', 'weather_precip_type',

--- a/mapApp/serializers.py
+++ b/mapApp/serializers.py
@@ -32,7 +32,7 @@ class IncidentSerializer(GeoFeatureModelSerializer):
                   'infrastructure_changed_date')
 
 
-class IncidentWeatherSerializer(GeoFeatureModelSerializer):
+class OldIncidentWeatherSerializer(GeoFeatureModelSerializer):
     # HACK There's no elegant way to serialize a one-to-one field that I could find :(
     # Nested relationships makes it hard to analyze the exported data
     weather_summary = serializers.CharField(source='weather.summary')

--- a/mapApp/serializers.py
+++ b/mapApp/serializers.py
@@ -31,6 +31,12 @@ class IncidentSerializer(GeoFeatureModelSerializer):
                   'direction', 'turning', 'age', 'birthmonth', 'sex', 'pk', 'impact','infrastructure_changed',
                   'infrastructure_changed_date')
 
+class WeatherSerializer(serializers.ModelSerializer):
+    incident = IncidentSerializer()
+    class Meta:
+        model = Weather
+        fields = '__all__'
+
 
 class OldIncidentWeatherSerializer(GeoFeatureModelSerializer):
     # HACK There's no elegant way to serialize a one-to-one field that I could find :(

--- a/mapApp/templates/mapApp/navbar.html
+++ b/mapApp/templates/mapApp/navbar.html
@@ -10,6 +10,7 @@
 {% url 'admin:index' as admin %}
 {% url 'mapApp:collision-list' as collisionList %}
 {% url 'mapApp:incident-list' as incidentWeatherList %}
+{% url 'mapApp:incident-only-list' as incidentOnlyList %}
 {% url 'mapApp:nearmiss-list' as nearmissList %}
 {% url 'mapApp:hazard-list' as hazardList %}
 {% url 'mapApp:theft-list' as theftList %}
@@ -92,6 +93,7 @@
             <li role="presentation" class="dropdown-header">{% trans "Admin options" %}</li>
             <li><a href="{{ admin }}"><small><span class="fa fa-wrench"></span> {% trans "Admin" %}</small></a></li>
             <li><a href="{{ incidentWeatherList }}.json"><small><span class="fa fa-download"></span> {% trans "Export Incidents + Weather" %}</small></a></li>
+            <li><a href="{{ incidentOnlyList }}.json"><small><span class="fa fa-download"></span> {% trans "Export Incidents (no weather)" %}</small></a></li>
             <li><a href="{{ collisionList }}.json"><small><span class="fa fa-download"></span> {% trans "Export Collisions" %}</small></a></li>
             <li><a href="{{ nearmissList }}.json"><small><span class="fa fa-download"></span> {% trans "Export Nearmisses" %}</small></a></li>
             <li><a href="{{ hazardList }}.json"><small><span class="fa fa-download"></span> {% trans "Export Hazards" %}</small></a></li>

--- a/mapApp/urls.py
+++ b/mapApp/urls.py
@@ -44,6 +44,7 @@ urlpatterns = [
 
 urlpatterns += format_suffix_patterns([
     url(r'^old-incidents/?$', views.IncidentList.as_view(), name='old-incident-list'),
+    url(r'^incidents/?$', views.IncidentWeatherList.as_view(), name='incident-list'),
     url(r'^collisions/?$', views.CollisionList.as_view(), name='collision-list'),
     url(r'^nearmiss/?$', views.NearmissList.as_view(), name='nearmiss-list'),
     url(r'^hazards/?$', views.HazardList.as_view(), name='hazard-list'),

--- a/mapApp/urls.py
+++ b/mapApp/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
 ]
 
 urlpatterns += format_suffix_patterns([
-    url(r'^incidents/?$', views.IncidentList.as_view(), name='incident-list'),
+    url(r'^old-incidents/?$', views.IncidentList.as_view(), name='old-incident-list'),
     url(r'^collisions/?$', views.CollisionList.as_view(), name='collision-list'),
     url(r'^nearmiss/?$', views.NearmissList.as_view(), name='nearmiss-list'),
     url(r'^hazards/?$', views.HazardList.as_view(), name='hazard-list'),

--- a/mapApp/urls.py
+++ b/mapApp/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
 ]
 
 urlpatterns += format_suffix_patterns([
+    url(r'^incidents-only/?$', views.IncidentOnlyList.as_view(), name='incident-only-list'),
     url(r'^old-incidents/?$', views.IncidentList.as_view(), name='old-incident-list'),
     url(r'^incidents/?$', views.IncidentWeatherList.as_view(), name='incident-list'),
     url(r'^collisions/?$', views.CollisionList.as_view(), name='collision-list'),

--- a/mapApp/views/__init__.py
+++ b/mapApp/views/__init__.py
@@ -10,7 +10,7 @@ from .recentReports import recentReports
 from .restApi import (AlertAreaDetail, AlertAreaList, APNSDeviceDetail,
                       APNSDeviceList, CollisionList, FilteredHazardList,
                       FilteredTheftList, GCMDeviceDetail, GCMDeviceList,
-                      HazardList, IncidentList, IncidentWeatherList, NearmissList, OfficialList,
+                      HazardList, IncidentOnlyList, IncidentList, IncidentWeatherList, NearmissList, OfficialList,
                       TheftList, TinyCollisionList, TinyHazardList,
                       TinyNearMissList, TinyNewInfrastructureList,
                       TinyTheftList, UserDetail, UserList, XHRCollisionInfo,

--- a/mapApp/views/__init__.py
+++ b/mapApp/views/__init__.py
@@ -10,7 +10,7 @@ from .recentReports import recentReports
 from .restApi import (AlertAreaDetail, AlertAreaList, APNSDeviceDetail,
                       APNSDeviceList, CollisionList, FilteredHazardList,
                       FilteredTheftList, GCMDeviceDetail, GCMDeviceList,
-                      HazardList, IncidentList, NearmissList, OfficialList,
+                      HazardList, IncidentList, IncidentWeatherList, NearmissList, OfficialList,
                       TheftList, TinyCollisionList, TinyHazardList,
                       TinyNearMissList, TinyNewInfrastructureList,
                       TinyTheftList, UserDetail, UserList, XHRCollisionInfo,

--- a/mapApp/views/restApi.py
+++ b/mapApp/views/restApi.py
@@ -366,6 +366,22 @@ class APNSDeviceDetail(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class IncidentOnlyList(APIView):
+    """
+    Lists incidents without joining weather data.
+    """
+    def get(self, request, format=None):
+
+        # Extract bounding box Url parameter
+        bbstr = request.GET.get('bbox', '-180,-90,180,90')
+        bbox = stringToPolygon(bbstr)
+
+        incidents = list(Incident.objects.filter(geom__within=bbox))
+
+        serializer = IncidentSerializer(incidents, many=True)
+        return Response(serializer.data)
+
+
 class IncidentList(APIView):
     """
     Old way to list all incident and weather data.

--- a/mapApp/views/restApi.py
+++ b/mapApp/views/restApi.py
@@ -1,5 +1,5 @@
-from mapApp.models import Incident, Hazard, Theft, Official, AlertArea, NewInfrastructure
-from mapApp.serializers import IncidentSerializer, HazardSerializer, TheftSerializer, FilteredHazardSerializer, FilteredTheftSerializer, OfficialSerializer, AlertAreaSerializer, UserSerializer, GCMDeviceSerializer, APNSDeviceSerializer, OldIncidentWeatherSerializer,TinyIncidentSerializer,TinyXHRIncidentSerializer,TinyHazSerializer,TinyXHRHazSerializer,TinyTheftSerializer,TinyXHRTheftSerializer,TinyNewInfrastructureSerializer,TinyXHRNewInfrastructureSerializer
+from mapApp.models import Incident, Hazard, Theft, Official, AlertArea, NewInfrastructure, Weather
+from mapApp.serializers import IncidentSerializer, HazardSerializer, TheftSerializer, FilteredHazardSerializer, FilteredTheftSerializer, OfficialSerializer, AlertAreaSerializer, UserSerializer, GCMDeviceSerializer, APNSDeviceSerializer, OldIncidentWeatherSerializer,TinyIncidentSerializer,TinyXHRIncidentSerializer,TinyHazSerializer,TinyXHRHazSerializer,TinyTheftSerializer,TinyXHRTheftSerializer,TinyNewInfrastructureSerializer,TinyXHRNewInfrastructureSerializer, WeatherSerializer
 from django.http import Http404
 from django.contrib.gis.geos import Polygon
 from rest_framework.views import APIView
@@ -379,6 +379,18 @@ class IncidentList(APIView):
         incidents = list(Incident.objects.filter(geom__within=bbox))
 
         serializer = OldIncidentWeatherSerializer(incidents, many=True)
+        return Response(serializer.data)
+
+class IncidentWeatherList(APIView):
+    """
+    Faster incident weather view
+    """
+    def get(self, request):
+        # Extract bounding box Url parameter
+        bbstr = request.GET.get('bbox', '-180,-90,180,90')
+        bbox = stringToPolygon(bbstr)
+        queryset = Weather.objects.select_related('incident').filter(incident__geom__within=bbox)
+        serializer = WeatherSerializer(queryset, many=True)
         return Response(serializer.data)
 
 

--- a/mapApp/views/restApi.py
+++ b/mapApp/views/restApi.py
@@ -1,5 +1,5 @@
 from mapApp.models import Incident, Hazard, Theft, Official, AlertArea, NewInfrastructure
-from mapApp.serializers import IncidentSerializer, HazardSerializer, TheftSerializer, FilteredHazardSerializer, FilteredTheftSerializer, OfficialSerializer, AlertAreaSerializer, UserSerializer, GCMDeviceSerializer, APNSDeviceSerializer, IncidentWeatherSerializer,TinyIncidentSerializer,TinyXHRIncidentSerializer,TinyHazSerializer,TinyXHRHazSerializer,TinyTheftSerializer,TinyXHRTheftSerializer,TinyNewInfrastructureSerializer,TinyXHRNewInfrastructureSerializer
+from mapApp.serializers import IncidentSerializer, HazardSerializer, TheftSerializer, FilteredHazardSerializer, FilteredTheftSerializer, OfficialSerializer, AlertAreaSerializer, UserSerializer, GCMDeviceSerializer, APNSDeviceSerializer, OldIncidentWeatherSerializer,TinyIncidentSerializer,TinyXHRIncidentSerializer,TinyHazSerializer,TinyXHRHazSerializer,TinyTheftSerializer,TinyXHRTheftSerializer,TinyNewInfrastructureSerializer,TinyXHRNewInfrastructureSerializer
 from django.http import Http404
 from django.contrib.gis.geos import Polygon
 from rest_framework.views import APIView
@@ -368,7 +368,7 @@ class APNSDeviceDetail(APIView):
 
 class IncidentList(APIView):
     """
-    List all incidents with all weather and point data.
+    Old way to list all incident and weather data.
     """
     def get(self, request, format=None):
 
@@ -378,7 +378,7 @@ class IncidentList(APIView):
 
         incidents = list(Incident.objects.filter(geom__within=bbox))
 
-        serializer = IncidentWeatherSerializer(incidents, many=True)
+        serializer = OldIncidentWeatherSerializer(incidents, many=True)
         return Response(serializer.data)
 
 

--- a/mapApp/views/restApi.py
+++ b/mapApp/views/restApi.py
@@ -401,7 +401,7 @@ class IncidentWeatherList(APIView):
     """
     Faster incident weather view
     """
-    def get(self, request):
+    def get(self, request, format=None):
         # Extract bounding box Url parameter
         bbstr = request.GET.get('bbox', '-180,-90,180,90')
         bbox = stringToPolygon(bbstr)

--- a/mapApp/views/restApi.py
+++ b/mapApp/views/restApi.py
@@ -1,5 +1,5 @@
 from mapApp.models import Incident, Hazard, Theft, Official, AlertArea, NewInfrastructure, Weather
-from mapApp.serializers import IncidentSerializer, HazardSerializer, TheftSerializer, FilteredHazardSerializer, FilteredTheftSerializer, OfficialSerializer, AlertAreaSerializer, UserSerializer, GCMDeviceSerializer, APNSDeviceSerializer, OldIncidentWeatherSerializer,TinyIncidentSerializer,TinyXHRIncidentSerializer,TinyHazSerializer,TinyXHRHazSerializer,TinyTheftSerializer,TinyXHRTheftSerializer,TinyNewInfrastructureSerializer,TinyXHRNewInfrastructureSerializer, WeatherSerializer
+from mapApp import serializers as s
 from django.http import Http404
 from django.contrib.gis.geos import Polygon
 from rest_framework.views import APIView
@@ -26,11 +26,11 @@ class CollisionList(APIView):
 
         collisions = list(Incident.objects.filter(p_type__exact="collision").filter(geom__within=bbox))
 
-        serializer = IncidentSerializer(collisions, many=True)
+        serializer = s.IncidentSerializer(collisions, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = IncidentSerializer(data=request.data)
+        serializer = s.IncidentSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             if serializer.data['properties'] is not None:
@@ -57,11 +57,11 @@ class NearmissList(APIView):
         bbox = stringToPolygon(bbstr)
 
         nearmiss = list(Incident.objects.filter(p_type__exact="nearmiss").filter(geom__within=bbox))
-        serializer = IncidentSerializer(nearmiss, many=True)
+        serializer = s.IncidentSerializer(nearmiss, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = IncidentSerializer(data=request.data)
+        serializer = s.IncidentSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             if serializer.data['properties'] is not None:
@@ -88,11 +88,11 @@ class HazardList(APIView):
         bbox = stringToPolygon(bbstr)
 
         hazards = list(Hazard.objects.exclude(expires_date__lt=datetime.datetime.now()).exclude(hazard_fixed=True).filter(geom__within=bbox))
-        serializer = HazardSerializer(hazards, many=True)
+        serializer = s.HazardSerializer(hazards, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = HazardSerializer(data=request.data)
+        serializer = s.HazardSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             if serializer.data['properties'] is not None:
@@ -119,11 +119,11 @@ class TheftList(APIView):
         bbox = stringToPolygon(bbstr)
 
         thefts = list(Theft.objects.filter(geom__within=bbox))
-        serializer = TheftSerializer(thefts, many=True)
+        serializer = s.TheftSerializer(thefts, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = TheftSerializer(data=request.data)
+        serializer = s.TheftSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             if serializer.data['properties'] is not None:
@@ -149,7 +149,7 @@ class FilteredHazardList(APIView):
         bbstr = request.GET.get('bbox', '0,0,0,0')
         bbox = stringToPolygon(bbstr)
         hazards = list(Hazard.objects.filter(geom__within=bbox))
-        serializer = FilteredHazardSerializer(hazards, many=True)
+        serializer = s.FilteredHazardSerializer(hazards, many=True)
         return Response(serializer.data)
 
 class FilteredTheftList(APIView):
@@ -165,7 +165,7 @@ class FilteredTheftList(APIView):
         bbox = stringToPolygon(bbstr)
 
         thefts = list(Theft.objects.filter(geom__within=bbox))
-        serializer = FilteredTheftSerializer(thefts, many=True)
+        serializer = s.FilteredTheftSerializer(thefts, many=True)
         return Response(serializer.data)
 
 class OfficialList(APIView):
@@ -179,12 +179,12 @@ class OfficialList(APIView):
         bbox = stringToPolygon(bbstr)
 
         official = list(Official.objects.filter(geom__within=bbox))
-        serializer = OfficialSerializer(official, many=True)
+        serializer = s.OfficialSerializer(official, many=True)
         return Response(serializer.data)
 
     """ No need to allow submission of official data through the API yet
     def post(self, request, format=None):
-        serializer = OfficialSerializer(data=request.data)
+        serializer = s.OfficialSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -201,11 +201,11 @@ class AlertAreaList(APIView):
 
     def get(self, request, format=None):
         alertareas = list(AlertArea.objects.filter(user=request.user))
-        serializer = AlertAreaSerializer(alertareas, many=True)
+        serializer = s.AlertAreaSerializer(alertareas, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = AlertAreaSerializer(data=request.data)
+        serializer = s.AlertAreaSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save(user=self.request.user, email=self.request.user.email)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -227,12 +227,12 @@ class AlertAreaDetail(APIView):
 
     def get(self, request, pk, format=None):
         alertarea = self.get_object(pk)
-        serializer = AlertAreaSerializer(alertarea)
+        serializer = s.AlertAreaSerializer(alertarea)
         return Response(serializer.data)
 
     def put(self, request, pk, format=None):
         alertarea = self.get_object(pk)
-        serializer = AlertAreaSerializer(alertarea, data=request.data)
+        serializer = s.AlertAreaSerializer(alertarea, data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
@@ -246,12 +246,12 @@ class AlertAreaDetail(APIView):
 
 class UserList(generics.ListAPIView):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = s.UserSerializer
 
 
 class UserDetail(generics.RetrieveAPIView):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = s.UserSerializer
 
 
 class GCMDeviceList(APIView):
@@ -264,11 +264,11 @@ class GCMDeviceList(APIView):
     def get(self, request, format=None):
         #gcmDevices = list(GCMDevice.objects.filter(user=request.user))
         gcmDevices = list(GCMDevice.objects.all())
-        serializer = GCMDeviceSerializer(gcmDevices, many=True)
+        serializer = s.GCMDeviceSerializer(gcmDevices, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = GCMDeviceSerializer(data=request.data)
+        serializer = s.GCMDeviceSerializer(data=request.data)
         if serializer.is_valid():
             # Ensure the registration_id is only in the GCMDevice table once
             if GCMDevice.objects.filter(registration_id = request.data['registration_id']) is not None:
@@ -293,12 +293,12 @@ class GCMDeviceDetail(APIView):
 
     def get(self, request, registration_id, format=None):
         gcmDevice = self.get_object(registration_id)
-        serializer = GCMDeviceSerializer(gcmDevice)
+        serializer = s.GCMDeviceSerializer(gcmDevice)
         return Response(serializer.data)
 
     def put(self, request, registration_id, format=None):
         gcmDevice = self.get_object(registration_id)
-        serializer = GCMDeviceSerializer(gcmDevice, data=request.data)
+        serializer = s.GCMDeviceSerializer(gcmDevice, data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
@@ -320,11 +320,11 @@ class APNSDeviceList(APIView):
     def get(self, request, format=None):
         #gcmDevices = list(GCMDevice.objects.filter(user=request.user))
         apnsDevices = list(APNSDevice.objects.all())
-        serializer = APNSDeviceSerializer(apnsDevices, many=True)
+        serializer = s.APNSDeviceSerializer(apnsDevices, many=True)
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        serializer = APNSDeviceSerializer(data=request.data)
+        serializer = s.APNSDeviceSerializer(data=request.data)
         if serializer.is_valid():
             # Ensure the registration_id is only in the APNSDevice table once
             if APNSDevice.objects.filter(registration_id = request.data['registration_id']) is not None:
@@ -349,12 +349,12 @@ class APNSDeviceDetail(APIView):
 
     def get(self, request, registration_id, format=None):
         apnsDevice = self.get_object(registration_id)
-        serializer = APNSDeviceSerializer(apnsDevice)
+        serializer = s.APNSDeviceSerializer(apnsDevice)
         return Response(serializer.data)
 
     def put(self, request, registration_id, format=None):
         apnsDevice = self.get_object(registration_id)
-        serializer = APNSDeviceSerializer(apnsDevice, data=request.data)
+        serializer = s.APNSDeviceSerializer(apnsDevice, data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
@@ -378,7 +378,7 @@ class IncidentOnlyList(APIView):
 
         incidents = list(Incident.objects.filter(geom__within=bbox))
 
-        serializer = IncidentSerializer(incidents, many=True)
+        serializer = s.IncidentSerializer(incidents, many=True)
         return Response(serializer.data)
 
 
@@ -394,7 +394,7 @@ class IncidentList(APIView):
 
         incidents = list(Incident.objects.filter(geom__within=bbox))
 
-        serializer = OldIncidentWeatherSerializer(incidents, many=True)
+        serializer = s.OldIncidentWeatherSerializer(incidents, many=True)
         return Response(serializer.data)
 
 class IncidentWeatherList(APIView):
@@ -406,7 +406,7 @@ class IncidentWeatherList(APIView):
         bbstr = request.GET.get('bbox', '-180,-90,180,90')
         bbox = stringToPolygon(bbstr)
         queryset = Weather.objects.select_related('incident').filter(incident__geom__within=bbox)
-        serializer = WeatherSerializer(queryset, many=True)
+        serializer = s.WeatherSerializer(queryset, many=True)
         return Response(serializer.data)
 
 
@@ -432,7 +432,7 @@ class TinyCollisionList(APIView):
 
         collisionsQuerySet = Incident.objects.filter(p_type__exact="collision").filter(geom__within=bbox).exclude(infrastructure_changed=True).order_by('-date')
 
-        serializer = TinyIncidentSerializer(collisionsQuerySet, many=True)
+        serializer = s.TinyIncidentSerializer(collisionsQuerySet, many=True)
         return Response(serializer.data)
 
 class XHRCollisionInfo(APIView):
@@ -444,7 +444,7 @@ class XHRCollisionInfo(APIView):
         # grab the pk and filter and find only the one record that matched
         in_pk = request.GET.get('pk')
         collisionsQuerySet = Incident.objects.get(pk=in_pk)
-        serializer = TinyXHRIncidentSerializer(collisionsQuerySet, many=False)
+        serializer = s.TinyXHRIncidentSerializer(collisionsQuerySet, many=False)
         return Response(serializer.data)
 
 class TinyNearMissList(APIView):
@@ -459,7 +459,7 @@ class TinyNearMissList(APIView):
 
         nearmissQuerySet = Incident.objects.filter(p_type__exact="nearmiss").filter(geom__within=bbox).exclude(infrastructure_changed=True).order_by('-date')
 
-        serializer = TinyIncidentSerializer(nearmissQuerySet, many=True)
+        serializer = s.TinyIncidentSerializer(nearmissQuerySet, many=True)
         return Response(serializer.data)
 
 class XHRNearMissInfo(APIView):
@@ -471,7 +471,7 @@ class XHRNearMissInfo(APIView):
         # grab the pk and filter and find only the one record that matched
         in_pk = request.GET.get('pk')
         collisionsQuerySet = Incident.objects.get(pk=in_pk)
-        serializer = TinyXHRIncidentSerializer(collisionsQuerySet, many=False)
+        serializer = s.TinyXHRIncidentSerializer(collisionsQuerySet, many=False)
         return Response(serializer.data)
 
 class TinyHazardList(APIView):
@@ -487,7 +487,7 @@ class TinyHazardList(APIView):
 		#Hazard.objects.select_related('point').exclude(expires_date__lt=now).exclude(hazard_fixed=True).order_by('-date')[:1],
         hazardQuerySet = Hazard.objects.select_related('point').filter(geom__within=bbox).exclude(expires_date__lt=datetime.datetime.now()).exclude(hazard_fixed=True).order_by('-date')
 
-        serializer = TinyHazSerializer(hazardQuerySet, many=True)
+        serializer = s.TinyHazSerializer(hazardQuerySet, many=True)
         return Response(serializer.data)
 
 class XHRHazardInfo(APIView):
@@ -499,7 +499,7 @@ class XHRHazardInfo(APIView):
         # grab the pk and filter and find only the one record that matched
         in_pk = request.GET.get('pk')
         hazardQuerySet = Hazard.objects.get(pk=in_pk)
-        serializer = TinyXHRHazSerializer(hazardQuerySet,many=False)
+        serializer = s.TinyXHRHazSerializer(hazardQuerySet,many=False)
         return Response(serializer.data)
 
 
@@ -514,7 +514,7 @@ class TinyTheftList(APIView):
         bbox = stringToPolygon(bbstr)
 
         theftQuerySet = Theft.objects.select_related('point').all().filter(geom__within=bbox).exclude(infrastructure_changed=True).order_by('-date')
-        serializer = TinyTheftSerializer(theftQuerySet, many=True)
+        serializer = s.TinyTheftSerializer(theftQuerySet, many=True)
         return Response(serializer.data)
 
 class XHRTheftInfo(APIView):
@@ -526,7 +526,7 @@ class XHRTheftInfo(APIView):
         # grab the pk and filter and find only the one record that matched
         in_pk = request.GET.get('pk')
         theftQuerySet = Theft.objects.get(pk=in_pk)
-        serializer = TinyXHRTheftSerializer(theftQuerySet, many=False)
+        serializer = s.TinyXHRTheftSerializer(theftQuerySet, many=False)
         return Response(serializer.data)
 
 class TinyNewInfrastructureList(APIView):
@@ -540,7 +540,7 @@ class TinyNewInfrastructureList(APIView):
         bbox = stringToPolygon(bbstr)
 		#select_related('point').
         niQuerySet = NewInfrastructure.objects.select_related('point').filter(geom__within=bbox).exclude(expires_date__lt=datetime.datetime.now()).order_by('-date')
-        serializer = TinyNewInfrastructureSerializer(niQuerySet, many=True)
+        serializer = s.TinyNewInfrastructureSerializer(niQuerySet, many=True)
         return Response(serializer.data)
 
 class XHRNewInfrastructureInfo(APIView):
@@ -552,5 +552,5 @@ class XHRNewInfrastructureInfo(APIView):
         # grab the pk and filter and find only the one record that matched
         in_pk = request.GET.get('pk')
         niQuerySet = NewInfrastructure.objects.get(pk=in_pk)
-        serializer = TinyXHRNewInfrastructureSerializer(niQuerySet, many=False)
+        serializer = s.TinyXHRNewInfrastructureSerializer(niQuerySet, many=False)
         return Response(serializer.data)


### PR DESCRIPTION
This PR originally added report_date and ebike to the incident serializer. When looking at the code I noticed the incident serializer linked the incident + weather models field by field, and the team had recently reported not being able to download the incidents data.  

1. To start I added an endpoint to download just the incident data (with report_date and ebike) without the weather data linked. I wanted this to be called '/incidents' and the endpoint with both incidents and weather to be '/incidents-weather' or something, but since it is a public facing API I opted to prioritize consistency. The new endpoint is just called '/incidents-only' and '/incidents' refers to incidents + weather.

2. I moved the existing incident endpoint to '/incidents-old' so that we could have access to it and compare download format and times, I can remove this once it's approved.

3. I changed '/incidents' to use select_related which joins the tables in the sql query, so only one trip to the db is required instead of fetching weather data for every incident one by one. When running locally, this brought the download time down from ~13 minutes to ~30 seconds

Django debug toolbar showing the extra sql queries per request:
![image](https://user-images.githubusercontent.com/3713996/202618897-1eac02af-8043-4a51-9d35-5b1247e79f4f.png)

It does change the output a little bit, the weather data is one json level up instead of being nested under 'properties'. Will need to run this by the team to make sure they can accommodate the update in any scripts they are using.

Example of the new output:

`{
        "incident": {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    -123.1030046869182,
                    49.26202386753346
                ]
            },
            "properties": {
                "i_type": "Near collision with moving object or vehicle",
                "incident_with": "Vehicle, side",
                "date": "2014-10-16T10:30:00",
                "report_date": "2014-10-17T04:50:16.439000",
                "p_type": "nearmiss",
                "personal_involvement": "NA",
                "details": "",
                "injury": "No injury",
                "trip_purpose": "Social reason",
                "regular_cyclist": "Y",
                "helmet": "Y",
                "road_conditions": null,
                "sightlines": null,
                "cars_on_roadside": null,
                "bike_lights": "NL",
                "terrain": "Flat",
                "aggressive": null,
                "intersection": null,
                "witness_vehicle": null,
                "bicycle_type": null,
                "ebike": null,
                "direction": "W",
                "turning": "Heading straight",
                "age": null,
                "birthmonth": "2",
                "sex": "F",
                "pk": 156,
                "impact": null,
                "infrastructure_changed": false,
                "infrastructure_changed_date": null
            }
        },
        "summary": "Clear",
        "sunrise_time": "2014-10-16T07:36:11",
        "sunset_time": "2014-10-16T18:21:56",
        "dawn": false,
        "dusk": false,
        "precip_intensity": 0.0686,
        "precip_probability": 0.07,
        "precip_type": "rain",
        "temperature": 11.34,
        "black_ice_risk": false,
        "wind_speed": 12.13,
        "wind_bearing": 84.0,
        "wind_bearing_str": "E",
        "visibility_km": -1.0
    }`