### PR TITLE
Update to GA-4

### DIFF
--- a/mapApp/templates/mapApp/base.html
+++ b/mapApp/templates/mapApp/base.html
@@ -27,16 +27,15 @@
   <link href="{% static 'mapApp/css/common.css' %}" rel="stylesheet">
   {% block headerCSS %}{% endblock %}
 
-  <!-- Google analytics tracker -->
-  <script async>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-53442345-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGNTWHQE1C"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-TGNTWHQE1C');
   </script>
 </head>
 


### PR DESCRIPTION
Updating to Google Analytics 4. This new tag is linked/associated to the old Google Universal Analytics tag.