### PR TITLE
hidden 'make report' instructions on mobile devices

### DIFF
--- a/mapApp/static/mapApp/css/common.css
+++ b/mapApp/static/mapApp/css/common.css
@@ -232,7 +232,7 @@ body h1{
 /* Mobile info popup on mobile phones */
 .tip-msg{
 	position: absolute;
-	top: 60px;
+	top: 80px;
 	left: 0px;
 	right: 0px;
 	height: 23px;

--- a/mapApp/templates/mapApp/util/draw.html
+++ b/mapApp/templates/mapApp/util/draw.html
@@ -246,7 +246,7 @@ function mobileDrawing(){
 
 <!-- Mobile tooltip to explain the double tapping -->
 {% if request.user_agent.is_mobile %}
-<div class="tip-msg alert-info alert-dismissable">
+<div class="tip-msg alert-info alert-dismissible mb-1">
     <div class="close">&times;</div>
     <center>{% trans "Double tap a location to submit a report" %}</center>
 </div>

--- a/mapApp/templates/mapApp/util/draw.html
+++ b/mapApp/templates/mapApp/util/draw.html
@@ -246,7 +246,7 @@ function mobileDrawing(){
 
 <!-- Mobile tooltip to explain the double tapping -->
 {% if request.user_agent.is_mobile %}
-<div class="tip-msg alert-info alert-dismissible mb-1">
+<div class="tip-msg alert-info alert-dismissible">
     <div class="close">&times;</div>
     <center>{% trans "Double tap a location to submit a report" %}</center>
 </div>


### PR DESCRIPTION
**Problem**
For mobile users, the instructions creating a report by tapping twice is mostly hidden at the top of the map.

**Solution**
I edited the styling for the tip-msg class in common.css file in the mapApp/css folder. The styling for the banner was set to have an absolute position 60px from the top of the screen. I changed this value to 80px which now makes the instruction banner fully visible.

I also fixed the bootstrap classname of directions element from ".alert-dismissable" to ".alert-dismissible" which now adds extra padding to the element's close button.

**Testing**

Open the staging server on your phone, where this branch is now deployed as of 09/27/2023. You can also open up the staging server on your computer, open up the inspector, and change the device view. Make sure to clear your browser cache after resetting the device view.

You should see a blue banner with instructions and a close button. Clicking the close button should remove the instructions.

<img width="767" alt="Screen Shot 2023-09-27 at 3 18 50 PM" src="https://github.com/SPARLab/BikeMaps/assets/115373509/1fa09712-676c-4d73-9d8b-7f750165adbb">

